### PR TITLE
Seccomp filters source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # go-seccomp
+
+This repository holds the source code for the "Go Seccomp Filters" blog posts.
+
+See both parts here:
+
+* https://dev.bitolog.com/go-seccomp-filters-part-1/
+* https://dev.bitolog.com/go-seccomp-filters-part-2/

--- a/main.go
+++ b/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	seccomp "github.com/seccomp/libseccomp-golang"
+	"syscall"
+)
+
+func main() {
+	err := loadSeccompFilter()
+	if err != nil {
+		fmt.Println(fmt.Sprintf("Failed to load seccomp filter: %v", err))
+		return
+	}
+
+	// Running the whitelisted code
+	err = syscall.Mkdir("/tmp/info", 0600)
+	if err != nil {
+		fmt.Println(fmt.Sprintf("Failed creating folder: %v", err))
+		return
+	}
+	fmt.Println("Folder created successfully")
+
+	// Trying to run non permitted syscalls
+	fmt.Println("Trying to get current working directory")
+	wd, err := syscall.Getwd()
+	if err != nil {
+		fmt.Println(fmt.Sprintf("Failed getting current working directory: %v", err))
+		return
+	}
+	fmt.Println(fmt.Sprintf("Current working directory is: %s", wd))
+}
+
+func loadSeccompFilter() error {
+	// The filter defaults to fail all syscalls
+	filter, err := seccomp.NewFilter(seccomp.ActErrno.SetReturnCode(int16(syscall.EPERM)))
+	if err != nil {
+		return err
+	}
+	// Whitelist relevant syscalls and load the filter
+	for _, name := range []string{
+		"futex", "mkdirat", "nanosleep", "readlinkat",
+		"write", "mmap", "fcntl", "sigaltstack",
+		"rt_sigprocmask", "arch_prctl", "gettid",
+		"read", "close", "rt_sigaction", "clone",
+		"execve", "uname", "mlock", "sched_getaffinity", "openat",
+	} {
+		syscallID, err := seccomp.GetSyscallFromName(name)
+		if err != nil {
+			return err
+		}
+		err = filter.AddRule(syscallID, seccomp.ActAllow)
+		if err != nil {
+			return err
+		}
+	}
+	return filter.Load()
+}


### PR DESCRIPTION
- Loading a seccomp filter which whitelists the mkdir function syscalls
- Trying to run any other syscalls would result in failure
- Try to run a wd syscall and fail as expected